### PR TITLE
Create a PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,59 @@
+#### Description
+
+< describe change here >
+
+< if you used a previous To Do item from another PR, please quote & reference it >
+
+
+----
+#### Issues # and Action
+
+----
+#### TO DO / Noteworthy
+< describe any remaining tasks, blocks, tech debt, or future ideas >
+
+
+----
+#### Features
+- [ ] New Feature
+- [ ] Expand Feature
+- [ ] Optimize/Improve Feature
+
+
+----
+#### Testing
+- [ ] No Testing
+- [ ] Some Testing
+- [ ] Sufficient Testing
+
+- [ ] **I have left notes near functions that have not been tested**
+- [ ] **I have included intentionally skipped / failing / empty tests as a reminder to add/improve these later**
+
+- [ ] Tests have been changed
+- [ ] Existing tests are now failing / skipped
+
+----
+#### Deployment
+
+< deployment issue card # >
+
+- [ ] This is a complete feature, ready for deployment
+- [ ] This is a partial feature, NOT ready for deployment
+
+
+----
+#### API Changes
+(please detail in description)
+- [ ] New API
+- [ ] Existing API, New Endpoint
+
+- [ ] **I have updated the README.md**
+
+----
+#### Tech Changes
+(please detail in description)
+- [ ] New Functional Library
+- [ ] New Testing Library
+- [ ] New Debugging Tool
+
+- [ ] **I have updated the README.md**


### PR DESCRIPTION
@JoelSmith123 

I've been using a template like this, where everything in '<>' either gets deleted or replaced with the intention and we link to issue cards in various places (like an Issue card to deploy features, keeping master and deployed separate states). Let me know what you think! I'd love to see templates you use as well - link me somewhere if you have one, or comment with what you'd change! Thanks!

This is an example of how I've used this template in the past:
https://github.com/Kate-v2/Quantified_Self_FE/pull/54